### PR TITLE
chore(renovate): prevent automerge for major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["breaking-change"],
+      "automerge": false
     }
   ],
   "separateMinorPatch": false,


### PR DESCRIPTION
- Add a new Renovate rule to specifically handle major dependency updates.
- Disable automerge for major version bumps to allow for manual review.
- Apply a "breaking-change" label to major updates for better visibility.
- Ensure major updates are reviewed and tested before merging to prevent regressions.